### PR TITLE
Add Kyonggi University domain

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi University


### PR DESCRIPTION
Please add Kyonggi University (kyonggi.ac.kr) to the JetBrains student email whitelist.
This file was generated from the JetBrains Education portal.